### PR TITLE
Fix test_build_dicom_image unit test

### DIFF
--- a/test/test_fhir2dicom4ortho.py
+++ b/test/test_fhir2dicom4ortho.py
@@ -3,6 +3,7 @@ import test
 from fhir2dicom4ortho.task_store import TaskStore
 from fhir2dicom4ortho.tasks import _build_dicom_image, TASK_DRAFT, TASK_COMPLETED, TASK_FAILED, TASK_REJECTED, TASK_INPROGRESS
 from fhir.resources.bundle import Bundle
+from dicom4ortho.utils import get_scheduled_protocol_code
 import unittest
 
 class TestTasks(unittest.TestCase):
@@ -19,7 +20,7 @@ class TestTasks(unittest.TestCase):
 
         ds = orthodontic_photograph.to_dataset()
         print(ds)
-        code = orthodontic_photograph.get_scheduled_protocol_code()
+        code = get_scheduled_protocol_code(ds)
         self.assertIsNotNone(code)
         self.assertEqual(code.CodeValue, "EV20")
         ds.save_as(os.path.join(test.current_dir,"test_build_dicom_image.dcm"))


### PR DESCRIPTION
Fix this error on the unit-test test_fhir2dicom4ortho.py file

======================================================================
ERROR: test_build_dicom_image (__main__.TestTasks)
Test the _build_dicom_image function.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/work/PROGETTI/fhir2dicom4ortho/test/test_fhir2dicom4ortho.py", line 22, in test_build_dicom_image
    code = orthodontic_photograph.get_scheduled_protocol_code()
AttributeError: 'OrthodonticPhotograph' object has no attribute 'get_scheduled_protocol_code'

----------------------------------------------------------------------
Ran 1 test in 31.911s